### PR TITLE
Remove golangci-lint from Travis execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ install:
   - export GOBIN="$GOPATH/bin"
   - export PATH="$PATH:$GOBIN"
   - go env
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.10.2
 script:
-  - golangci-lint run ./...
   - go test       ./...
   - go test -race ./... -coverprofile=coverage.txt -covermode=atomic
 after_success:


### PR DESCRIPTION
Migrate to https://golangci.com/ service.