### PR TITLE
Rename ReaderWriter to ReadWriter

### DIFF
--- a/resp.go
+++ b/resp.go
@@ -56,18 +56,18 @@ func (t Type) String() string {
 	return string(t)
 }
 
-// ReaderWriter embeds a Reader and a Writer in a single allocation for an io.ReadWriter.
+// ReadWriter embeds a Reader and a Writer in a single allocation for an io.ReadWriter.
 //
 // A single Reader and a single Writer method can be called concurrently, given the Read and Write methods of the
 // underlying io.ReadWriter are safe for concurrent use.
-type ReaderWriter struct {
+type ReadWriter struct {
 	Reader
 	Writer
 }
 
-// NewReaderWriter returns a new ReaderWriter that uses the given io.ReadWriter.
-func NewReaderWriter(rw io.ReadWriter) *ReaderWriter {
-	var rrw ReaderWriter
+// NewReadWriter returns a new ReadWriter that uses the given io.ReadWriter.
+func NewReadWriter(rw io.ReadWriter) *ReadWriter {
+	var rrw ReadWriter
 	rrw.Reset(rw)
 	return &rrw
 }
@@ -75,7 +75,7 @@ func NewReaderWriter(rw io.ReadWriter) *ReaderWriter {
 // Reset resets the embedded Reader and Writer to use the given io.ReadWriter.
 //
 // Reset must not be called concurrently with any other method
-func (rrw *ReaderWriter) Reset(rw io.ReadWriter) {
+func (rrw *ReadWriter) Reset(rw io.ReadWriter) {
 	rrw.Reader.Reset(rw)
 	rrw.Writer.Reset(rw)
 }

--- a/resp_test.go
+++ b/resp_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func copyReaderToWriter(tb testing.TB, rw *resp.ReaderWriter) {
+func copyReaderToWriter(tb testing.TB, rw *resp.ReadWriter) {
 	for {
 		ty, err := rw.Peek()
 		if err == io.EOF {
@@ -81,12 +81,12 @@ func getTestFiles(tb testing.TB) []string {
 	return files
 }
 
-type simpleReaderWriter struct {
+type simpleReadWriter struct {
 	io.Reader
 	io.Writer
 }
 
-func testReaderWriterUsingFile(t *testing.T, fileName string) {
+func testReadWriterUsingFile(t *testing.T, fileName string) {
 	file, err := os.Open(fileName)
 	if err != nil {
 		t.Fatalf("failed to read file %s: %s", fileName, err)
@@ -96,7 +96,7 @@ func testReaderWriterUsingFile(t *testing.T, fileName string) {
 	var out bytes.Buffer
 	inHash, outHash := sha1.New(), sha1.New()
 
-	rw := resp.NewReaderWriter(&simpleReaderWriter{
+	rw := resp.NewReadWriter(&simpleReadWriter{
 		Reader: io.TeeReader(file, inHash),
 		Writer: io.MultiWriter(&out, outHash),
 	})
@@ -109,7 +109,7 @@ func testReaderWriterUsingFile(t *testing.T, fileName string) {
 	}
 }
 
-func TestReaderWriter(t *testing.T) {
+func TestReadWriter(t *testing.T) {
 	for _, file := range getTestFiles(t) {
 		file := file
 
@@ -117,24 +117,24 @@ func TestReaderWriter(t *testing.T) {
 		testName = testName[:len(testName) - len(filepath.Ext(testName))]
 
 		t.Run(testName, func(t *testing.T) {
-			testReaderWriterUsingFile(t, file)
+			testReadWriterUsingFile(t, file)
 		})
 	}
 }
 
-func benchmarkReaderWriterUsingFile(b *testing.B, fileName string) {
+func benchmarkReadWriterUsingFile(b *testing.B, fileName string) {
 	fileBytes, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		b.Fatalf("failed to read file %s: %s", fileName, err)
 	}
 
 	fileBytesReader := bytes.NewReader(nil)
-	srw := &simpleReaderWriter{
+	srw := &simpleReadWriter{
 		Reader: fileBytesReader,
 		Writer: ioutil.Discard,
 	}
 
-	rw := resp.NewReaderWriter(nil)
+	rw := resp.NewReadWriter(nil)
 
 	b.ResetTimer()
 
@@ -146,7 +146,7 @@ func benchmarkReaderWriterUsingFile(b *testing.B, fileName string) {
 	}
 }
 
-func BenchmarkReaderWriter(b *testing.B) {
+func BenchmarkReadWriter(b *testing.B) {
 	for _, file := range getTestFiles(b) {
 		file := file
 
@@ -154,7 +154,7 @@ func BenchmarkReaderWriter(b *testing.B) {
 		testName = testName[:len(testName) - len(filepath.Ext(testName))]
 
 		b.Run(testName, func(b *testing.B) {
-			benchmarkReaderWriterUsingFile(b, file)
+			benchmarkReadWriterUsingFile(b, file)
 		})
 	}
 }


### PR DESCRIPTION
The new name follows the Go naming conventions and aligns with the respective type from the `io` package.