### PR TITLE
Handle *.resp files as binary files in Git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.resp text eol=crlf
+*.resp binary


### PR DESCRIPTION
This avoids Git always marking the `*.resp` files as changed on unix-like systems.