### PR TITLE
Remove int return value from string Read* methods.

### DIFF
--- a/reader_integration_test.go
+++ b/reader_integration_test.go
@@ -20,10 +20,10 @@ func mustWriteLines(tb testing.TB, w io.Writer, lines ...string) {
 	}
 }
 
-func assertReadBytesFunc(tb testing.TB, typeName string, f func([]byte) (int, []byte, error), expected []byte) {
+func assertReadBytesFunc(tb testing.TB, typeName string, f func([]byte) ([]byte, error), expected []byte) {
 	tb.Helper()
 
-	if _, got, err := f(nil); err != nil {
+	if got, err := f(nil); err != nil {
 		tb.Fatalf("failed to read %s: %s", typeName, err)
 	} else if !bytes.Equal(got, expected) {
 		tb.Fatalf("got %q, expected %q", got, expected)

--- a/resp_test.go
+++ b/resp_test.go
@@ -33,7 +33,7 @@ func copyReaderToWriter(tb testing.TB, rw *resp.ReadWriter) {
 				tb.Fatalf("failed to write array header for array of size %d: %s", n, err)
 			}
 		case resp.TypeBulkString:
-			_, s, err := rw.ReadBulkString(nil)
+			s, err := rw.ReadBulkString(nil)
 			if err != nil {
 				tb.Fatalf("failed to bulk string: %s", err)
 			}
@@ -41,7 +41,7 @@ func copyReaderToWriter(tb testing.TB, rw *resp.ReadWriter) {
 				tb.Fatalf("failed to write bulk string %q: %s", s, err)
 			}
 		case resp.TypeError:
-			_, s, err := rw.ReadError(nil)
+			s, err := rw.ReadError(nil)
 			if err != nil {
 				tb.Fatalf("failed to read error: %s", err)
 			}
@@ -57,7 +57,7 @@ func copyReaderToWriter(tb testing.TB, rw *resp.ReadWriter) {
 				tb.Fatalf("failed to write integer size %d: %s", n, err)
 			}
 		case resp.TypeSimpleString:
-			_, s, err := rw.ReadSimpleString(nil)
+			s, err := rw.ReadSimpleString(nil)
 			if err != nil {
 				tb.Fatalf("failed to read simple string: %s", err)
 			}


### PR DESCRIPTION
This removes the first return value from ReadBulkString, ReadError and
ReadSimpleString, which contained the size of the appended string.

The length can be easily calculated by comparing the slice length before
and after reading the value and is rarely useful.