### PR TITLE
Provide methods for writing strings and byte slices

### DIFF
--- a/resp_test.go
+++ b/resp_test.go
@@ -37,7 +37,7 @@ func copyReaderToWriter(tb testing.TB, rw *resp.ReadWriter) {
 			if err != nil {
 				tb.Fatalf("failed to bulk string: %s", err)
 			}
-			if _, err := rw.WriteBulkString(s); err != nil {
+			if _, err := rw.WriteBulkStringBytes(s); err != nil {
 				tb.Fatalf("failed to write bulk string %q: %s", s, err)
 			}
 		case resp.TypeError:
@@ -45,7 +45,7 @@ func copyReaderToWriter(tb testing.TB, rw *resp.ReadWriter) {
 			if err != nil {
 				tb.Fatalf("failed to read error: %s", err)
 			}
-			if _, err := rw.WriteError(s); err != nil {
+			if _, err := rw.WriteErrorBytes(s); err != nil {
 				tb.Fatalf("failed to write error %q: %s", s, err)
 			}
 		case resp.TypeInteger:
@@ -61,7 +61,7 @@ func copyReaderToWriter(tb testing.TB, rw *resp.ReadWriter) {
 			if err != nil {
 				tb.Fatalf("failed to read simple string: %s", err)
 			}
-			if _, err := rw.WriteSimpleString(s); err != nil {
+			if _, err := rw.WriteSimpleStringBytes(s); err != nil {
 				tb.Fatalf("failed to write simple string %q: %s", s, err)
 			}
 		case resp.TypeInvalid:

--- a/writer.go
+++ b/writer.go
@@ -44,6 +44,15 @@ func (rw *Writer) writeNumber(prefix byte, n int64) (int, error) {
 	return rw.w.Write(rw.buf)
 }
 
+func (rw *Writer) writeString(prefix byte, s string) (int, error) {
+	rw.buf = rw.buf[:0]
+	rw.buf = append(rw.buf, prefix)
+	rw.buf = append(rw.buf, s...)
+	rw.buf = append(rw.buf, '\r', '\n')
+
+	return rw.w.Write(rw.buf)
+}
+
 // Write allows writing raw data to the underlying io.Writer.
 //
 // It implements the io.Writer interface.
@@ -85,8 +94,25 @@ func (rw *Writer) WriteBulkStringHeader(n int) (int, error) {
 	return rw.writeNumber('$', int64(n))
 }
 
-// WriteBulkString writes the given byte slice s as bulk string.
-func (rw *Writer) WriteBulkString(s []byte) (int, error) {
+// WriteBulkString writes the string s as bulk string.
+//
+// If you need to write a nil bulk string, use WriteBulkStringBytes instead.
+func (rw *Writer) WriteBulkString(s string) (int, error) {
+	n, err := rw.WriteBulkStringHeader(len(s))
+	if err != nil {
+		return n, err
+	}
+
+	rw.buf = rw.buf[:0]
+	rw.buf = append(rw.buf, s...)
+	rw.buf = append(rw.buf, '\r', '\n')
+
+	n1, err := rw.w.Write(rw.buf)
+	return n + n1, err
+}
+
+// WriteBulkStringBytes writes the byte slice s as bulk string.
+func (rw *Writer) WriteBulkStringBytes(s []byte) (int, error) {
 	if s == nil {
 		return rw.WriteBulkStringHeader(-1)
 	}
@@ -104,17 +130,27 @@ func (rw *Writer) WriteBulkString(s []byte) (int, error) {
 	return n + n1, err
 }
 
-// WriteError writes the given byte slice unvalidated as a simple error.
-func (rw *Writer) WriteError(s []byte) (int, error) {
+// WriteError writes the string s unvalidated as a simple error.
+func (rw *Writer) WriteError(s string) (int, error) {
+	return rw.writeString('-', s)
+}
+
+// WriteErrorBytes writes the byte slice s unvalidated as a simple error.
+func (rw *Writer) WriteErrorBytes(s []byte) (int, error) {
 	return rw.writeBytes('-', s)
 }
 
-// WriteInteger writes the given integer as the native RESP integer type.
+// WriteInteger writes the integer i as the native RESP integer type.
 func (rw *Writer) WriteInteger(i int) (int, error) {
 	return rw.writeNumber(':', int64(i))
 }
 
-// WriteSimpleString writes the given byte slice unvalidated as a simple string.
-func (rw *Writer) WriteSimpleString(s []byte) (int, error) {
+// WriteSimpleString writes the string s unvalidated as a simple string.
+func (rw *Writer) WriteSimpleString(s string) (int, error) {
+	return rw.writeString('+', s)
+}
+
+// WriteSimpleStringBytes writes the byte slice s unvalidated as a simple string.
+func (rw *Writer) WriteSimpleStringBytes(s []byte) (int, error) {
 	return rw.writeBytes('+', s)
 }

--- a/writer_integration_test.go
+++ b/writer_integration_test.go
@@ -48,7 +48,7 @@ func mustWriteArrayHeader(tb testing.TB, w *resp.Writer, n int) {
 
 func mustWriteBulkString(tb testing.TB, w *resp.Writer, s []byte) {
 	tb.Helper()
-	mustWriteBytesFunc(tb, "bulk string", w.WriteBulkString, s)
+	mustWriteBytesFunc(tb, "bulk string", w.WriteBulkStringBytes, s)
 }
 
 func TestWriterIntegration(t *testing.T) {

--- a/writer_test.go
+++ b/writer_test.go
@@ -85,30 +85,68 @@ type simpleWriteCase struct {
 	In       []byte
 }
 
-func testSimpleWrite(tb testing.TB, input string, expected []byte, fn func(*resp.Writer, string) (int, error)) {
-	tb.Helper()
-
-	var buf bytes.Buffer
-	w := resp.NewWriter(&buf)
-
-	if _, err := fn(w, input); err != nil {
-		tb.Errorf("write failed: %s", err)
-	} else if got := buf.Bytes(); !bytes.Equal(got, expected) {
-		tb.Errorf("got %q, expected %q", got, expected)
+func prefixedSimpleWriteCases(prefix string) []simpleWriteCase {
+	return []simpleWriteCase{
+		{
+			Name:     "empty",
+			Expected: prefix + "\r\n",
+			In:       []byte{},
+		},
+		{
+			Name:     "nil",
+			Expected: prefix + "\r\n",
+			In:       nil,
+		},
+		{
+			Name:     "small",
+			Expected: prefix + "YO hello world\r\n",
+			In:       []byte("YO hello world"),
+		},
+		{
+			Name:     "invalid",
+			Expected: prefix + "YO hello\r\nworld\r\n",
+			In:       []byte("YO hello\r\nworld"),
+		},
 	}
 }
 
-func testSimpleWriteBytes(tb testing.TB, input, expected []byte, fn func(*resp.Writer, []byte) (int, error)) {
-	tb.Helper()
+func (s simpleWriteCase) run(t *testing.T,
+	stringsFunc func(*resp.Writer, string) (int, error),
+	bytesFunc func(*resp.Writer, []byte) (int, error)) {
 
-	var buf bytes.Buffer
-	w := resp.NewWriter(&buf)
+	t.Run(s.Name, func(t *testing.T) {
+		s.runBytes(t, bytesFunc)
 
-	if _, err := fn(w, input); err != nil {
-		tb.Errorf("write failed: %s", err)
-	} else if got := buf.Bytes(); !bytes.Equal(got, expected) {
-		tb.Errorf("got %q, expected %q", got, expected)
-	}
+		if s.In != nil {
+			s.runString(t, stringsFunc)
+		}
+	})
+}
+
+func (s simpleWriteCase) runBytes(t *testing.T, fn func(*resp.Writer, []byte) (int, error)) {
+	t.Run("Bytes", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := resp.NewWriter(&buf)
+
+		if _, err := fn(w, s.In); err != nil {
+			t.Errorf("write failed: %s", err)
+		} else if got := buf.String(); got != s.Expected {
+			t.Errorf("got %q, expected %q", got, s.Expected)
+		}
+	})
+}
+
+func (s simpleWriteCase) runString(t *testing.T, fn func(*resp.Writer, string) (int, error)) {
+	t.Run("String", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := resp.NewWriter(&buf)
+
+		if _, err := fn(w, string(s.In)); err != nil {
+			t.Errorf("write failed: %s", err)
+		} else if got := buf.String(); got != s.Expected {
+			t.Errorf("got %q, expected %q", got, s.Expected)
+		}
+	})
 }
 
 func TestWriterWrite(t *testing.T) {
@@ -250,15 +288,9 @@ func TestWriterWriteBulkString(t *testing.T) {
 			In:       []byte("hello\nworld!"),
 		},
 	} {
-		test := test
-
-		t.Run(test.Name, func(t *testing.T) {
-			if test.In != nil {
-				testSimpleWrite(t, string(test.In), []byte(test.Expected), (*resp.Writer).WriteBulkString)
-			}
-
-			testSimpleWriteBytes(t, test.In, []byte(test.Expected), (*resp.Writer).WriteBulkStringBytes)
-		})
+		test.run(t,
+			(*resp.Writer).WriteBulkString,
+			(*resp.Writer).WriteBulkStringBytes)
 	}
 }
 
@@ -334,37 +366,10 @@ func BenchmarkWriterWriteBulkStringHeader(b *testing.B) {
 }
 
 func TestWriterWriteError(t *testing.T) {
-	for _, test := range []simpleWriteCase{
-		{
-			Name:     "empty",
-			Expected: "-\r\n",
-			In:       []byte{},
-		},
-		{
-			Name:     "nil",
-			Expected: "-\r\n",
-			In:       nil,
-		},
-		{
-			Name:     "small",
-			Expected: "-ERR hello world\r\n",
-			In:       []byte("ERR hello world"),
-		},
-		{
-			Name:     "invalid",
-			Expected: "-ERR hello\r\nworld\r\n",
-			In:       []byte("ERR hello\r\nworld"),
-		},
-	} {
-		test := test
-
-		t.Run(test.Name, func(t *testing.T) {
-			if test.In != nil {
-				testSimpleWrite(t, string(test.In), []byte(test.Expected), (*resp.Writer).WriteError)
-			}
-
-			testSimpleWriteBytes(t, test.In, []byte(test.Expected), (*resp.Writer).WriteErrorBytes)
-		})
+	for _, test := range prefixedSimpleWriteCases("-") {
+		test.run(t,
+			(*resp.Writer).WriteError,
+			(*resp.Writer).WriteErrorBytes)
 	}
 }
 
@@ -434,37 +439,10 @@ func BenchmarkWriterWriteInteger(b *testing.B) {
 }
 
 func TestWriterWriteSimpleString(t *testing.T) {
-	for _, test := range []simpleWriteCase{
-		{
-			Name:     "empty",
-			Expected: "+\r\n",
-			In:       []byte{},
-		},
-		{
-			Name:     "nil",
-			Expected: "+\r\n",
-			In:       nil,
-		},
-		{
-			Name:     "small",
-			Expected: "+OK hello world\r\n",
-			In:       []byte("OK hello world"),
-		},
-		{
-			Name:     "invalid",
-			Expected: "+OK hello\r\nworld\r\n",
-			In:       []byte("OK hello\r\nworld"),
-		},
-	} {
-		test := test
-
-		t.Run(test.Name, func(t *testing.T) {
-			if test.In != nil {
-				testSimpleWrite(t, string(test.In), []byte(test.Expected), (*resp.Writer).WriteSimpleString)
-			}
-
-			testSimpleWriteBytes(t, test.In, []byte(test.Expected), (*resp.Writer).WriteSimpleStringBytes)
-		})
+	for _, test := range prefixedSimpleWriteCases("+") {
+		test.run(t,
+			(*resp.Writer).WriteSimpleString,
+			(*resp.Writer).WriteSimpleStringBytes)
 	}
 }
 


### PR DESCRIPTION
This avoids the need for users to convert strings to byte slices when writing bulk strings, errors or simple strings.