### PR TITLE
Optimize BulkString writing by combining writes

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -98,17 +98,14 @@ func (rw *Writer) WriteBulkStringHeader(n int) (int, error) {
 //
 // If you need to write a nil bulk string, use WriteBulkStringBytes instead.
 func (rw *Writer) WriteBulkString(s string) (int, error) {
-	n, err := rw.WriteBulkStringHeader(len(s))
-	if err != nil {
-		return n, err
-	}
-
 	rw.buf = rw.buf[:0]
+	rw.buf = append(rw.buf, '$')
+	rw.buf = strconv.AppendUint(rw.buf, uint64(len(s)), 10)
+	rw.buf = append(rw.buf, '\r', '\n')
 	rw.buf = append(rw.buf, s...)
 	rw.buf = append(rw.buf, '\r', '\n')
 
-	n1, err := rw.w.Write(rw.buf)
-	return n + n1, err
+	return rw.w.Write(rw.buf)
 }
 
 // WriteBulkStringBytes writes the byte slice s as bulk string.
@@ -117,17 +114,14 @@ func (rw *Writer) WriteBulkStringBytes(s []byte) (int, error) {
 		return rw.WriteBulkStringHeader(-1)
 	}
 
-	n, err := rw.WriteBulkStringHeader(len(s))
-	if err != nil {
-		return n, err
-	}
-
 	rw.buf = rw.buf[:0]
+	rw.buf = append(rw.buf, '$')
+	rw.buf = strconv.AppendUint(rw.buf, uint64(len(s)), 10)
+	rw.buf = append(rw.buf, '\r', '\n')
 	rw.buf = append(rw.buf, s...)
 	rw.buf = append(rw.buf, '\r', '\n')
 
-	n1, err := rw.w.Write(rw.buf)
-	return n + n1, err
+	return rw.w.Write(rw.buf)
 }
 
 // WriteError writes the string s unvalidated as a simple error.


### PR DESCRIPTION
Speeds up writes for small bulk strings with minimal slow down for larger strings:

```name                                 old time/op  new time/op  delta
WriterWriteBulkStringHeader/0-8      34.7ns ± 1%  24.6ns ± 3%  -29.30%  (p=0.000 n=18+20)
WriterWriteBulkStringHeader/1-8      35.7ns ± 3%  25.5ns ± 3%  -28.73%  (p=0.000 n=20+20)
WriterWriteBulkStringHeader/10-8     36.3ns ± 3%  26.1ns ± 4%  -28.23%  (p=0.000 n=20+20)
WriterWriteBulkStringHeader/100-8    47.7ns ± 4%  37.1ns ± 3%  -22.16%  (p=0.000 n=20+20)
WriterWriteBulkStringHeader/1000-8   60.1ns ± 3%  50.2ns ± 3%  -16.54%  (p=0.000 n=20+20)
WriterWriteBulkStringHeader/10000-8   148ns ± 4%   158ns ± 3%   +6.57%  (p=0.000 n=20+20)
```